### PR TITLE
Support `detect_buffers` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "author": "Simon Tabor <me@simontabor.com> (http://simontabor.com/)",
   "license": "MIT",
   "repository": {
-    "type" : "git",
-    "url" : "git://github.com/gosquared/redis-clustr.git"
+    "type": "git",
+    "url": "git://github.com/gosquared/redis-clustr.git"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "redis": "^0.12.1"
+    "redis": "^2.2.5"
   },
   "optionalDependencies": {
     "hiredis": "^0.4.0"

--- a/src/redisClustr.js
+++ b/src/redisClustr.js
@@ -135,6 +135,7 @@ RedisClustr.prototype.selectClient = function(key) {
   var self = this;
 
   if (Array.isArray(key)) key = key[0];
+  if (Buffer.isBuffer(key)) key = key.toString();
 
   // support for hash tags to keep keys on the same slot
   // http://redis.io/topics/cluster-spec#multiple-keys-operations


### PR DESCRIPTION
Fixed a crash when passing keys as buffers when using `detect_buffers: true`.