### PR TITLE
tolerant undefined callback

### DIFF
--- a/src/setupCommands.js
+++ b/src/setupCommands.js
@@ -12,6 +12,10 @@ module.exports = function(Class) {
         args[i] = arguments[i];
       }
 
+      if (args.length > 0 && typeof args[args.length - 1] === 'undefined') {
+        args.pop();
+      }
+
       this[fn](cmd, conf, args);
       return this;
     };

--- a/test/miscCommands.js
+++ b/test/miscCommands.js
@@ -1,6 +1,6 @@
 'use strict';
 // not really tests but being used to ensure things are working
-var RedisClustr = require('../src/redisClustr');
+var RedisClustr = require('../src/RedisClustr');
 
 var c = new RedisClustr({
   servers: [
@@ -31,6 +31,18 @@ c.set('hi', 650);
 c.eval('redis.call("set", KEYS[1], ARGV[1]); return redis.call("get", KEYS[1]);', 1, 'evalkey', 'evalval', function(err, resp) {
   console.log('eval', err, resp);
 });
+
+function delKey(callback) {
+  c.del('whateverkey', callback);
+}
+
+delKey(function(err) {
+  if (err) return console.error('del error', err);
+
+  console.log('del');
+});
+
+delKey();
 
 var todo = [
   function(done) {


### PR DESCRIPTION
As reproduced in test:
``` javascript
function delKey(callback) {
  c.del('whateverkey', callback);
}

delKey();
```

`callback` can be undefined in many condition, it's a bad practice, but hard to avoid them all easily.
On the other side, node-redis can handle `undefined` callback smoothly, so I'd hope redis-clustr keep the interface consistent.

The real pain is while this issue happens, it's hard to debug, because stack info are lost. :sweat: