### PR TITLE
Travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+redis-git

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - "6"
   - "4"
 
+env:
+  - REDIS_VERSION=3.2.3
+  - REDIS_VERSION=3.0.7
+
 install:
   - npm install
   - test/setup-redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - "6"
+  - "4"
+
+install:
+  - npm install
+  - test/setup-redis
+
+before_script: test/start-redis
+after_script: test/stop-redis

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -206,7 +206,7 @@ RedisClustr.prototype.getSlots = function(cb) {
 
         // array of all clients, clients[0] = master, others are slaves
         var clients = s.slice(2).map(function(c, index) {
-          var name = c.join(':');
+          var name = c[0] + ':' + c[1];
           if (seenClients.indexOf(name) === -1) seenClients.push(name);
 
           return self.getClient(c[1], c[0], index === 0);

--- a/test/setup-redis
+++ b/test/setup-redis
@@ -4,16 +4,13 @@ REDIS_VERSION=${REDIS_VERSION:-3.2.3}
 
 if [ ! -e redis-git ]
 then
-  git clone https://github.com/antirez/redis redis-git
+  git clone https://github.com/antirez/redis redis-git --branch $REDIS_VERSION
 else
   pushd redis-git
   git fetch
+  git checkout $REDIS_VERSION
   popd
 fi
-
-pushd redis-git
-git checkout $REDIS_VERSION
-popd
 
 make -C redis-git -j $(nproc)
 

--- a/test/setup-redis
+++ b/test/setup-redis
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+REDIS_VERSION=${REDIS_VERSION:-3.2.3}
+
+if [ ! -e redis-git ]
+then
+  git clone https://github.com/antirez/redis redis-git
+else
+  pushd redis-git
+  git fetch
+  popd
+fi
+
+pushd redis-git
+git checkout $REDIS_VERSION
+popd
+
+make -C redis-git -j $(nproc)
+
+gem install redis

--- a/test/start-redis
+++ b/test/start-redis
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+redis_conf() {
+  cat <<-EOF
+daemonize yes
+port 700$1
+cluster-node-timeout 5000
+pidfile /tmp/redis_cluster_node$1.pid
+logfile /tmp/redis_cluster_node$1.log
+save ""
+appendonly no
+cluster-enabled yes
+cluster-config-file /tmp/redis_cluster_node$1.conf
+EOF
+}
+
+for i in {1..6}
+do
+  redis_conf $i | redis-git/src/redis-server -
+done
+
+sleep 3
+
+echo "yes" | ruby redis-git/src/redis-trib.rb create --replicas 1 127.0.0.1:700{1..6}
+
+sleep 3

--- a/test/stop-redis
+++ b/test/stop-redis
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for i in {1..6}
+do
+  kill $(cat /tmp/redis_cluster_node$i.pid)
+done
+
+rm -f /tmp/redis_cluster_node{1..6}.conf dump.rdb appendonly.aof


### PR DESCRIPTION
Supersedes and closes #13 
Closes #14 (improvements can still be made but that issue was specifically for travis automated tests)

This PR enables travis tests against node 4/6 & redis 3.0.7/3.2.3 (I need to see whether we're good to test against the head of 3.0 / 3.2 branches on redis, for the time being this just uses the release tags so it'll need updating for new versions)

At the moment it's just our super-simple tests, but we can look to improve them further down the line. This would at least have helped flag issues such as #12 

Borrows heavily from https://github.com/Grokzen/travis-redis-cluster