### PR TITLE
Added benchmarks and changed 'double-ended-queue' to 'denque' - small perf increase.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 redis-git
+yarn.lock

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,92 @@
+var Benchmark = require('benchmark');
+var RedisClustr = require('./../src/RedisClustr');
+var largeStr = (new Array(4096 + 1).join('-'));
+var hugeStr = (new Array((4 * 1024 * 1024) + 1).join('-'));
+console.log('\r\n');
+require('./print');
+console.log('\r\n');
+
+var suite = new Benchmark.Suite();
+
+var redis = new RedisClustr({
+    servers: [
+        {
+            host: '127.0.0.1',
+            port: 30001
+        }
+    ]
+});
+
+
+redis.once('connect', () => {
+    suite.run();
+});
+
+redis.once('error', (err) => {
+    console.error(err);
+});
+
+suite
+    .add('PING', {
+        defer: true,
+        fn: function (deferred) {
+            redis.ping(() => deferred.resolve());
+        }
+    })
+
+    .add('INCR', {
+        defer: true,
+        fn: function (deferred) {
+            redis.incr('incrtest', () => deferred.resolve());
+        }
+    })
+
+    .add('SET 4B str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.set('moo', '1234', () => deferred.resolve());
+        }
+    })
+
+    .add('GET 4B str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.get('moo', () => deferred.resolve());
+        }
+    })
+
+    .add('SET 4KB str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.set('moobar', largeStr, () => deferred.resolve());
+        }
+    })
+
+    .add('GET 4KB str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.get('moobar', () => deferred.resolve());
+        }
+    })
+
+    .add('SET 4MB str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.set('moobarhuge', hugeStr, () => deferred.resolve());
+        }
+    })
+
+    .add('GET 4MB str', {
+        defer: true,
+        fn: function (deferred) {
+            redis.get('moobarhuge', () => deferred.resolve());
+        }
+    })
+
+    .on('complete', function () {
+        redis.quit();
+    })
+
+    .on('cycle', function (e) {
+        console.log('' + e.target);
+    });

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -12,7 +12,7 @@ var redis = new RedisClustr({
     servers: [
         {
             host: '127.0.0.1',
-            port: 30001
+            port: 7006
         }
     ]
 });

--- a/benchmark/print.js
+++ b/benchmark/print.js
@@ -1,0 +1,24 @@
+'use strict';
+
+console.log('Platform:');
+
+var os = require('os');
+var v8 = process.versions.v8;
+var node = process.versions.node;
+var plat = os.type() + ' ' + os.release() + ' ' + os.arch() + '\nNode.JS '+ node + '\nV8 '+ v8;
+
+var cpus = os.cpus().map(function (cpu) {
+    return cpu.model;
+}).reduce(function (o, model) {
+    if (!o[model]) o[model] = 0;
+    o[model]++;
+    return o;
+}, {});
+
+cpus = Object.keys(cpus).map(function (key) {
+    return key + ' \u00d7 ' + cpus[key];
+}).join('\n');
+
+console.log(plat + '\n' + cpus + '\n');
+
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "url": "git://github.com/gosquared/redis-clustr.git"
   },
   "scripts": {
-    "test": "mocha test/test.js"
+    "test": "mocha test/test.js",
+    "benchmark": "node benchmark/"
   },
   "dependencies": {
     "cluster-key-slot": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "mocha test/test.js"
   },
   "dependencies": {
+    "benchmark": "^2.1.1",
     "cluster-key-slot": "^1.0.5",
     "double-ended-queue": "^2.1.0-0",
     "redis": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "test": "mocha test/test.js"
   },
   "dependencies": {
-    "benchmark": "^2.1.1",
     "cluster-key-slot": "^1.0.5",
+    "denque": "^1.1.0",
     "double-ended-queue": "^2.1.0-0",
     "redis": "^2.6.0"
   },
   "devDependencies": {
+    "benchmark": "^2.1.1",
     "js-beautify": "^1.5.10",
     "mocha": "^2.3.4"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "cluster-key-slot": "^1.0.5",
     "denque": "^1.1.0",
-    "double-ended-queue": "^2.1.0-0",
     "redis": "^2.6.0"
   },
   "devDependencies": {

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -5,7 +5,7 @@ var redis = require('redis');
 var RedisBatch = require('./RedisBatch');
 var Events = require('events').EventEmitter;
 var util = require('util');
-var Queue = require('double-ended-queue');
+var Queue = require('denque');
 
 var RedisClustr = module.exports = function(config) {
   var self = this;


### PR DESCRIPTION
Recently wrote a faster double ended queue implementation [here](https://github.com/Salakar/denque) - I've switched out the 'double-ended-queue' dependency for this as it's considerably faster (maintains compatibility with api and node versions and 100% coverage - so nothings changed there)

(and added benchmarks in the process) \o/

### Before switch
![image](https://cloud.githubusercontent.com/assets/5347038/19476647/353cbf7e-9532-11e6-8da6-56fd83406939.png)
￼
### After switching to 'denque'
![image](https://cloud.githubusercontent.com/assets/5347038/19476653/3ed33e46-9532-11e6-94ba-c8dbdee9a757.png)

￼Ran the benchmarks several times, with denque is always faster. Couple of other performance tweaks that can be done on this repo - but i'll do a separate PR for that.