### PR TITLE
Add pre-defined commands support to batch() and multi()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-clustr",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Redis cluster client",
   "main": "src/RedisClustr.js",
   "keywords": [

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -614,9 +614,17 @@ setupCommands(RedisClustr);
  * @date   2014-11-19
  * @return {RedisBatch}   A RedisBatch which has a very similar interface                                                 to redis/
  */
-RedisClustr.prototype.batch = RedisClustr.prototype.multi = function() {
+RedisClustr.prototype.batch = RedisClustr.prototype.multi = function(commands) {
   var self = this;
-  return new RedisBatch(self);
+  var batch = new RedisBatch(self);
+
+  if (Array.isArray(commands) && commands.length > 0) {
+    commands.forEach(function (command) {
+      batch[command[0]](...command.slice(1));
+    });
+  }
+
+  return batch;
 };
 
 /**

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -620,7 +620,12 @@ RedisClustr.prototype.batch = RedisClustr.prototype.multi = function(commands) {
 
   if (Array.isArray(commands) && commands.length > 0) {
     commands.forEach(function (command) {
-      batch[command[0]](...command.slice(1));
+      var args = [];
+      if (command.length > 1) {
+        args = command.slice(1);
+      }
+
+      batch[command[0]].apply(batch, args);
     });
   }
 


### PR DESCRIPTION
This adds support for the following syntax supported by `node_redis` for `batch()` and `multi()`:

```js
var redis  = require("redis"),
    client = redis.createClient();

client.multi([
    ["mget", "multifoo", "multibar", redis.print],
    ["incr", "multifoo"],
    ["incr", "multibar"]
]).exec(function (err, replies) {
    console.log(replies);
});
```