### PR TITLE
Fix client selection for keyless commands and those with movable keys

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1,769 +1,119 @@
-// Generated using tools/commands.js and config/commandsConfig.js on Sun, 22 Nov 2015 23:03:06 GMT
+// Generated using tools/commands.js and config/commandsConfig.js on Wed, 21 Mar 2018 11:49:17 GMT
 
 module.exports = {
-  lindex: {
+  append: {
     multiKey: false,
     interval: 1,
-    readOnly: true
-  },
-  zrank: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zinterstore: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  persist: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  getrange: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  brpoplpush: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  zscore: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zrevrangebylex: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  replconf: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  sadd: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pfadd: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  getbit: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zincrby: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  hgetall: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zremrangebyscore: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  type: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  cluster: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  zrange: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  debug: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  bitcount: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  flushdb: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  sunionstore: {
-    multiKey: true,
-    interval: 1,
-    readOnly: false
-  },
-  smove: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  rpushx: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  zrangebylex: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  multi: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  sdiff: {
-    multiKey: true,
-    interval: 1,
-    readOnly: true
-  },
-  hscan: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zrevrank: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  punsubscribe: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  lset: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  psetex: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  hvals: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zrem: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  smembers: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zscan: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  dbsize: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  sinterstore: {
-    multiKey: true,
-    interval: 1,
-    readOnly: false
-  },
-  lastsave: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  evalsha: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  scan: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  unsubscribe: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  setex: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  scard: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  ping: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  bitpos: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  role: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  psubscribe: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  wait: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  config: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  publish: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  sdiffstore: {
-    multiKey: true,
-    interval: 1,
-    readOnly: false
-  },
-  lrange: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  hsetnx: {
-    multiKey: false,
-    interval: 1,
+    keyless: false,
     readOnly: false
   },
   asking: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
-  },
-  decr: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  client: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  linsert: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  spop: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  subscribe: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  lpushx: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  ltrim: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  migrate: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  llen: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zlexcount: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  psync: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  'restore-asking': {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  save: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  latency: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  setnx: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
   },
   auth: {
     multiKey: false,
     interval: 0,
-    readOnly: true
-  },
-  hmget: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  sinter: {
-    multiKey: true,
-    interval: 1,
-    readOnly: true
-  },
-  watch: {
-    multiKey: true,
-    interval: 1,
-    readOnly: true
-  },
-  strlen: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  sync: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  zrangebyscore: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  bitop: {
-    multiKey: true,
-    interval: 1,
-    readOnly: false
-  },
-  msetnx: {
-    multiKey: true,
-    interval: 2,
-    readOnly: false
-  },
-  hmset: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pfmerge: {
-    multiKey: true,
-    interval: 1,
-    readOnly: false
-  },
-  readwrite: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  sort: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  monitor: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  randomkey: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  incr: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  mget: {
-    group: function(resp) {
-      return resp.map(function(r) {
-        if (!r) return r;
-        return r[0];
-      });
-    },
-    multiKey: true,
-    interval: 1,
-    readOnly: true
-  },
-  hincrby: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  srandmember: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zremrangebyrank: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  script: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  srem: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  setrange: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  mset: {
-    group: function() {
-      return 'OK';
-    },
-    multiKey: true,
-    interval: 2,
-    readOnly: false
-  },
-  flushall: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  blpop: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  renamenx: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  select: {
-    multiKey: false,
-    interval: 0,
+    keyless: true,
     readOnly: true
   },
   bgrewriteaof: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  zcount: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  substr: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  sismember: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  incrby: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  hget: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zrevrangebyscore: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  setbit: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  time: {
+  bgsave: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  slaveof: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  hset: {
+  bitcount: {
     multiKey: false,
     interval: 1,
-    readOnly: false
-  },
-  dump: {
-    multiKey: false,
-    interval: 1,
+    keyless: false,
     readOnly: true
   },
-  move: {
-    multiKey: false,
+  bitop: {
+    multiKey: true,
     interval: 1,
+    keyless: false,
     readOnly: false
   },
-  sscan: {
+  bitpos: {
     multiKey: false,
     interval: 1,
+    keyless: false,
     readOnly: true
   },
-  append: {
+  blpop: {
     multiKey: false,
     interval: 1,
+    keyless: false,
     readOnly: false
-  },
-  discard: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  lpop: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pexpire: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pfdebug: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  readonly: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  get: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  zadd: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  hkeys: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  restore: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  exec: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  eval: {
-    multiKey: false,
-    interval: 0,
-    readOnly: false
-  },
-  set: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  expire: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  zremrangebylex: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pubsub: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  zcard: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  object: {
-    multiKey: false,
-    interval: 2,
-    readOnly: true
-  },
-  unwatch: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  keys: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  hdel: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  echo: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
-  },
-  pfselftest: {
-    multiKey: false,
-    interval: 0,
-    readOnly: true
   },
   brpop: {
     multiKey: false,
     interval: 1,
+    keyless: false,
     readOnly: false
   },
-  pttl: {
+  brpoplpush: {
     multiKey: false,
     interval: 1,
-    readOnly: true
-  },
-  hincrbyfloat: {
-    multiKey: false,
-    interval: 1,
+    keyless: false,
     readOnly: false
   },
-  hlen: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  slowlog: {
+  client: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  hexists: {
-    multiKey: false,
-    interval: 1,
-    readOnly: true
-  },
-  getset: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  lpush: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  info: {
+  cluster: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  rpoplpush: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  zunionstore: {
+  command: {
     multiKey: false,
     interval: 0,
-    readOnly: false
-  },
-  lrem: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  rpush: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pexpireat: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  zrevrange: {
-    multiKey: false,
-    interval: 1,
+    keyless: true,
     readOnly: true
   },
-  ttl: {
+  config: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  dbsize: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  debug: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  decr: {
     multiKey: false,
     interval: 1,
-    readOnly: true
+    keyless: false,
+    readOnly: false
+  },
+  decrby: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
   },
   del: {
     group: function(resp) {
@@ -775,61 +125,874 @@ module.exports = {
     },
     multiKey: true,
     interval: 1,
+    keyless: false,
     readOnly: false
   },
-  rename: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  bgsave: {
+  discard: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  decrby: {
+  dump: {
     multiKey: false,
     interval: 1,
-    readOnly: false
-  },
-  sunion: {
-    multiKey: true,
-    interval: 1,
+    keyless: false,
     readOnly: true
   },
-  shutdown: {
+  echo: {
     multiKey: false,
     interval: 0,
+    keyless: true,
     readOnly: true
   },
-  incrbyfloat: {
-    multiKey: false,
-    interval: 1,
-    readOnly: false
-  },
-  pfcount: {
-    multiKey: true,
-    interval: 1,
-    readOnly: true
-  },
-  command: {
+  eval: {
     multiKey: false,
     interval: 0,
-    readOnly: true
+    keyless: false,
+    readOnly: false
+  },
+  evalsha: {
+    multiKey: false,
+    interval: 0,
+    keyless: false,
+    readOnly: false
+  },
+  exec: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
   },
   exists: {
     multiKey: true,
     interval: 1,
+    keyless: false,
     readOnly: true
   },
-  rpop: {
+  expire: {
     multiKey: false,
     interval: 1,
+    keyless: false,
     readOnly: false
   },
   expireat: {
     multiKey: false,
     interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  flushall: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  flushdb: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  get: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  getbit: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  getrange: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  getset: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hdel: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hexists: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hget: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hgetall: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hincrby: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hincrbyfloat: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hkeys: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hlen: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hmget: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hmset: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hscan: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  hset: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hsetnx: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  hvals: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  incr: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  incrby: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  incrbyfloat: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  info: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  keys: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  lastsave: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  latency: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  lindex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  linsert: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  llen: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  lpop: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  lpush: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  lpushx: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  lrange: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  lrem: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  lset: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  ltrim: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  mget: {
+    group: function(resp) {
+      return resp.map(function(r) {
+        if (!r) return r;
+        return r[0];
+      });
+    },
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  migrate: {
+    multiKey: false,
+    interval: 0,
+    keyless: false,
+    readOnly: false
+  },
+  monitor: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  move: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  mset: {
+    group: function() {
+      return 'OK';
+    },
+    multiKey: true,
+    interval: 2,
+    keyless: false,
+    readOnly: false
+  },
+  msetnx: {
+    multiKey: true,
+    interval: 2,
+    keyless: false,
+    readOnly: false
+  },
+  multi: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  object: {
+    multiKey: false,
+    interval: 2,
+    keyless: false,
+    readOnly: true
+  },
+  persist: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  pexpire: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  pexpireat: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  pfadd: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  pfcount: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  pfdebug: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  pfmerge: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  pfselftest: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  ping: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  psetex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  psubscribe: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  psync: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  pttl: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  publish: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  pubsub: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  punsubscribe: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  randomkey: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  readonly: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  readwrite: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  rename: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  renamenx: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  replconf: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  restore: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  'restore-asking': {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  role: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  rpop: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  rpoplpush: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  rpush: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  rpushx: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  sadd: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  save: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  scan: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  scard: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  script: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  sdiff: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  sdiffstore: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  select: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  set: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  setbit: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  setex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  setnx: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  setrange: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  shutdown: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  sinter: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  sinterstore: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  sismember: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  slaveof: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: false
+  },
+  slowlog: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  smembers: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  smove: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  sort: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  spop: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  srandmember: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  srem: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  sscan: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  strlen: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  subscribe: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  substr: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  sunion: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  sunionstore: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  sync: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  time: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  ttl: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  type: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  unsubscribe: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  unwatch: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  wait: {
+    multiKey: false,
+    interval: 0,
+    keyless: true,
+    readOnly: true
+  },
+  watch: {
+    multiKey: true,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zadd: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zcard: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zcount: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zincrby: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zinterstore: {
+    multiKey: false,
+    interval: 0,
+    keyless: false,
+    readOnly: false
+  },
+  zlexcount: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrange: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrangebylex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrangebyscore: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrank: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrem: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zremrangebylex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zremrangebyrank: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zremrangebyscore: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: false
+  },
+  zrevrange: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrevrangebylex: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrevrangebyscore: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zrevrank: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zscan: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zscore: {
+    multiKey: false,
+    interval: 1,
+    keyless: false,
+    readOnly: true
+  },
+  zunionstore: {
+    multiKey: false,
+    interval: 0,
+    keyless: false,
     readOnly: false
   }
 };

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -270,7 +270,7 @@ RedisClustr.prototype.selectClient = function(key, conf) {
 
   // this command doesnt have keys, return any connection
   // NOTE: this means slaves may be used for no key commands regardless of slave config
-  if (conf.interval === 0) return self.getRandomConnection();
+  if (conf.keyless) return self.getRandomConnection();
 
   if (Array.isArray(key)) key = key[0];
   if (Buffer.isBuffer(key)) key = key.toString();
@@ -359,7 +359,7 @@ RedisClustr.prototype.doCommand = function(cmd, conf, args) {
   self.parseArgs(args, function(_, args, cb) {
     var key = args[0];
 
-    if (!key) return cb(new Error('no key for command: ' + cmd));
+    if (!key && !conf.keyless) return cb(new Error('no key for command: ' + cmd));
 
     var r = self.selectClient(key, conf);
     if (!r) return cb(new Error('couldn\'t get client'));

--- a/tools/commands.js
+++ b/tools/commands.js
@@ -9,11 +9,17 @@ redis.command(function(err, res) {
   redis.quit();
   if (err) return console.error(err);
 
+  // Ensure stable sorting of commands to avoid git diff churn every time we regenerate
+  res.sort(function(a, b) {
+    return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+  });
+
   for (var i = 0; i < res.length; i++) {
     var c = res[i];
     var cnf = extraConfig[c[0]] || {};
     cnf.multiKey = c[4] === -1;
     cnf.interval = c[5];
+    cnf.keyless = c[5] === 0 && c[2].indexOf('movablekeys') === -1;
     cnf.readOnly = c[2].indexOf('readonly') !== -1;
     commands[c[0]] = cnf;
   }


### PR DESCRIPTION
Prompted by #25 and #26 where we're incorrectly using the key interval being 0 to determine the target for a keyless command.

This PR includes an annoying amount of diff churn in `config/commands.js` but I've added some pre-sorting so it should be more stable next time we have to regenerate it.