### PR TITLE
Test against more recent versions of things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: node_js
 
 node_js:
+  - "8"
   - "6"
   - "4"
 
 env:
+  - REDIS_VERSION=4.0.8
+  - REDIS_VERSION=3.2.11
   - REDIS_VERSION=3.2.3
   - REDIS_VERSION=3.0.7
 


### PR DESCRIPTION
Since node v4 hits EOL very soon I would also like to drop support + tests for it and refactor to use a bunch of ES6+ features internally. That'll obviously be a breaking change though so will have to happen in a 2.0