### PR TITLE
fix: handle NR_CLOSED errors as connection errors

### DIFF
--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -79,8 +79,8 @@ RedisClustr.prototype.getClient = function(port, host, master) {
       err.code === 'NR_CLOSED' ||
       /Redis connection to .* failed.*/.test(err.message)
     ) {
-      // broken connection so force a new client to be created (node_redis will reconnect other errors)
-      if (err.code === 'CONNECTION_BROKEN') self.connections[name] = null;
+      // broken/closed connection so force a new client to be created (node_redis should reconnect other errors)
+      if (err.code === 'CONNECTION_BROKEN' || err.code === 'NR_CLOSED') self.connections[name] = null;
       self.emit('connectionError', err, cli);
       self.getSlots();
       return;

--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -76,6 +76,7 @@ RedisClustr.prototype.getClient = function(port, host, master) {
     if (
       err.code === 'CONNECTION_BROKEN' ||
       err.code === 'UNCERTAIN_STATE' ||
+      err.code === 'NR_CLOSED' ||
       /Redis connection to .* failed.*/.test(err.message)
     ) {
       // broken connection so force a new client to be created (node_redis will reconnect other errors)
@@ -563,10 +564,10 @@ RedisClustr.prototype.subscribeAll = function(exclude) {
   var cli = self.subscribeClient = self.createClient(con.connection_options.port, con.connection_options.host);
 
   cli.on('error', function(err) {
-    console.log(err);
     if (
       err.code === 'CONNECTION_BROKEN' ||
       err.code === 'UNCERTAIN_STATE' ||
+      err.code === 'NR_CLOSED' ||
       /Redis connection to .* failed.*/.test(err.message)
     ) {
       self.emit('connectionError', err, cli);


### PR DESCRIPTION
When testing cluster fail overs (especially when using pub/sub), Redis is emitting [NR_CLOSED](https://github.com/NodeRedis/node_redis#error-handling--v26) errors.

This can be treated as a connection error as it appears to have the same behaviour as the old `CONNECTION_BROKEN` errors.