### PR TITLE
Explicitly set 'slaves' setting

### DIFF
--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -25,6 +25,7 @@ var RedisClustr = module.exports = function(config) {
   self.subscriptions = null;
   self.ready = false;
   self.connected = false;
+  self.config.slaves = self.config.slaves || 'never';
 
   for (var i = 0; i < config.servers.length; i++) {
     var c = config.servers[i];


### PR DESCRIPTION
The documentation indicates that the 'slaves' setting defaults to
'never', but this default is never actually set anywhere. This commit
checks if the setting was provided by the user, and explicitly sets to
the indicated default 'never' if not provided.