### PR TITLE
Only get a random connection if the command is readOnly

### DIFF
--- a/src/RedisClustr.js
+++ b/src/RedisClustr.js
@@ -279,8 +279,8 @@ RedisClustr.prototype.getSlots = function(cb) {
 RedisClustr.prototype.selectClient = function(key, conf) {
   var self = this;
 
-  // this command doesnt have keys, return any connection
-  if (conf.keyless) return self.getRandomConnection();
+  // this command doesnt have keys and is read only, return any connection
+  if (conf.keyless && conf.ReadOnly) return self.getRandomConnection();
 
   if (Array.isArray(key)) key = key[0];
   if (Buffer.isBuffer(key)) key = key.toString();


### PR DESCRIPTION
This commit fixes a bug where a command that is keyless, but not read
only, could still try to operate on a slave. We don't want to get a
random connection in this case, but actually explicltly operate on the
master.